### PR TITLE
Disable SSL certificate checks

### DIFF
--- a/src/main/java/org/openbaton/clients/interfaces/client/openstack/DisableSSLValidation.java
+++ b/src/main/java/org/openbaton/clients/interfaces/client/openstack/DisableSSLValidation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2015 Fraunhofer FOKUS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openbaton.clients.interfaces.client.openstack;
+
+import javax.net.ssl.*;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+public class DisableSSLValidation {
+
+    public static void disableChecks() {
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            TrustManager[] trustManagerArray = { new NullX509TrustManager() };
+            sslContext.init(null, trustManagerArray, null);
+            HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
+            HttpsURLConnection.setDefaultHostnameVerifier(new NullHostnameVerifier());
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static class NullX509TrustManager implements X509TrustManager {
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        }
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        }
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+
+    private static class NullHostnameVerifier implements HostnameVerifier {
+        public boolean verify(String hostname, SSLSession session) {
+            return true;
+        }
+    }
+
+}

--- a/src/main/java/org/openbaton/clients/interfaces/client/openstack/OpenstackClient.java
+++ b/src/main/java/org/openbaton/clients/interfaces/client/openstack/OpenstackClient.java
@@ -70,6 +70,7 @@ import org.openbaton.catalogue.mano.common.DeploymentFlavour;
 import org.openbaton.catalogue.nfvo.*;
 import org.openbaton.catalogue.nfvo.Network;
 import org.openbaton.catalogue.nfvo.Subnet;
+import org.openbaton.clients.interfaces.client.openstack.DisableSSLValidation;
 import org.openbaton.exceptions.VimDriverException;
 import org.openbaton.plugin.PluginStarter;
 import org.openbaton.vim.drivers.interfaces.VimDriver;
@@ -124,8 +125,11 @@ public class OpenstackClient extends VimDriver {
         modules = ImmutableSet.<Module>of(new SLF4JLoggingModule());
         overrides = new Properties();
         overrides.setProperty(KeystoneProperties.CREDENTIAL_TYPE, CredentialTypes.PASSWORD_CREDENTIALS);
-        overrides.setProperty(Constants.PROPERTY_RELAX_HOSTNAME, "true");
-        overrides.setProperty(Constants.PROPERTY_TRUST_ALL_CERTS, "true");
+        String sslChecksDisabled = properties.getProperty("disable-ssl-certificate-checks", "false");
+        log.debug("Disable SSL certificate checks: {}", sslChecksDisabled);
+        if (sslChecksDisabled.trim().equals("true")) {
+            DisableSSLValidation.disableChecks();
+        }
     }
 
     private String getZone(VimInstance vimInstance) {

--- a/src/main/resources/plugin.conf.properties
+++ b/src/main/resources/plugin.conf.properties
@@ -20,3 +20,6 @@ type = openstack
 external-properties-file = /etc/openbaton/plugin/openstack/driver.properties
 
 dns-nameserver=8.8.8.8
+
+# Disables SSL certificate checks when communitation with OpenStack APIs.
+disable-ssl-certificate-checks = true


### PR DESCRIPTION
* This patch allows users to register and use OpenStack PoP instances
  with self-signed SSL certificates by default.
* To re-enable SSL certificate checks user can set config option
  "disable-ssl-certificate-checks" to "false".

See: openbaton/NFVO#8